### PR TITLE
Upgrade to http 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
--- Upgraded `http` to `0.2.0`
+- Upgraded `http` to `0.2.0`
 
 ## [0.3.1] - 2019-12-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+-- Upgraded `http` to `0.2.0`
+
 ## [0.3.1] - 2019-12-05
 ### Changed
 - Updated several dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 base64 = "0.11.0"
 bytes = "0.4.12"
 chrono = "0.4.10"
-http = "0.1.18"
+http = "0.2.0"
 lock_api = "0.3.2"
 parking_lot = "0.10.0"
 ring = { version = "0.16.9", optional = true }
@@ -32,7 +32,7 @@ twox-hash = { version = "1.5.0", default-features = false }
 url = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
-reqwest = { version = "0.9.22", default-features = false, features = [ "rustls-tls" ] }
+reqwest = { git = "https://github.com/seanmonstar/reqwest.git", rev = "18fd9a6", default-features = false, features = [ "rustls-tls", "blocking" ] }
 
 [features]
 default = ["gcp"]

--- a/examples/svc_account.rs
+++ b/examples/svc_account.rs
@@ -38,7 +38,7 @@ fn main() {
             scope_hash,
             ..
         } => {
-            let client = reqwest::Client::new();
+            let client = reqwest::blocking::Client::new();
 
             let (parts, body) = request.into_parts();
             let uri = parts.uri.to_string();
@@ -66,9 +66,7 @@ fn main() {
             response.copy_to(&mut writer).unwrap();
             let buffer = writer.into_inner();
 
-            let mut builder = http::Response::builder();
-
-            builder
+            let mut builder = http::Response::builder()
                 .status(response.status())
                 .version(response.version());
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -48,8 +48,7 @@ impl std::convert::TryInto<http::header::HeaderValue> for Token {
 
     fn try_into(self) -> Result<http::header::HeaderValue, crate::Error> {
         let auth_header_val = format!("{} {}", self.token_type, self.access_token);
-        let auth_header_val = bytes::Bytes::from(auth_header_val);
-        http::header::HeaderValue::from_shared(auth_header_val)
+        http::header::HeaderValue::from_str(&auth_header_val)
             .map_err(|e| crate::Error::from(http::Error::from(e)))
     }
 }


### PR DESCRIPTION

This also upgrades the reqwest dev dependency from latest master as it was also recently updated to use http 0.2.0 and was otherwise not compatible. Can still publish this package as it is just a dev dependency for the example

Fix #8