### PR TITLE
Allow usage in a wasm-web context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
-### Changed
-- Changed name of `Error::AuthError` to `Error::Auth`
-
 ### Added
 - Added new field to `Error::InvalidRsaKey`
-- Added new Error varient `Error::InvalidRsaKeyRejected` 
+- Added `Error::InvalidRsaKeyRejected` variant
+- [PR#37](https://github.com/EmbarkStudios/tame-oauth/pull/37) Added new feature `wasm-web`, which enables additional features in `chrono` and `ring` to allow `tame-oauth` to be used in a wasm browser context, as part of a fix for [#36](https://github.com/EmbarkStudios/tame-oauth/issues/36).
+
+### Changed
+- Changed name of `Error::AuthError` to `Error::Auth`
+- [PR#37](https://github.com/EmbarkStudios/tame-oauth/pull/37) replaced the usage of `parking_lot::Mutex` with just regular `std::sync::Mutex` as part of the fix for [#36](https://github.com/EmbarkStudios/tame-oauth/issues/36), this includes adding `Error::Poisoned`.
+
+### Removed
+- Removed `Error:Io` as it was never actually used.
 
 ## [0.4.7] - 2021-01-18
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,24 @@ maintenance = { status = "actively-developed" }
 doctest = false
 path = "src/lib.rs"
 
+[features]
+# This library was first created to support GCP oauth, if we add support for
+# other oauth providers this will most likely change to not have any default features
+default = ["gcp"]
+# Supports for GCP oauth2
+gcp = ["jwt", "url"]
+# Support for Json Web Tokens, ring is used for signing
+jwt = ["ring"]
+# This enables features in chrono and ring that are necessary to use this library
+# in a wasm32 web (browser) context. If you are using wasm outside the browser
+# you will need to target wasm32-wasi for the requisite functionality (time and random)
+wasm-web = ["chrono/wasmbind", "ring/wasm32_c"]
+
 [dependencies]
 base64 = "0.13" # Keep aligned with rustls
 chrono = "0.4"
 http = "0.2"
 lock_api = "0.4"
-parking_lot = "0.11"
 ring = { version = "0.16", optional = true }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
@@ -38,8 +50,3 @@ features = ["rustls-tls"]
 [dev-dependencies.tokio]
 version = "1.0"
 features = ["macros", "rt-multi-thread"]
-
-[features]
-default = ["gcp"]
-gcp = ["jwt", "url"]
-jwt = ["ring"]

--- a/README.md
+++ b/README.md
@@ -19,13 +19,20 @@
 * There are several other oauth crates available that have many more features and are easier to work with, if you don't care about what HTTP clients they use.
 * This crate requires more boilerplate to use.
 
+## Features
+
+* `gcp` (default) - Support for [GCP oauth2](https://developers.google.com/identity/protocols/oauth2)
+* `wasm-web` - Enables wasm features in `chrono` and `ring` needed for `tame-oauth` to be used in a wasm browser context. Note this feature should not be used when targetting wasm outside the browser context, in which case you would likely need to target `wasm32-wasi`.
+* `jwt` (default) - Support for [JSON Web Tokens](https://jwt.io/), required for `gcp`
+* `url` (default) - Url parsing, required for `gcp`
+
 ## Examples
 
 ### [svc_account](examples/svc_account.rs)
 
 Usage: `cargo run --example svc_account -- <key_path> <scope..>`
 
-A small example of using `tame-oauth` together with [reqwest](). Given a key file and 1 or more scopes, it will attempt to get a token that could be used to access resources in those scopes.
+A small example of using `tame-oauth` together with [reqwest](https://github.com/seanmonstar/reqwest). Given a key file and 1 or more scopes, it will attempt to get a token that could be used to access resources in those scopes.
 
 `cargo run --example svc_account -- ~/.secrets/super-sekret.json https://www.googleapis.com/auth/pubsub https://www.googleapis.com/auth/devstorage.read_only`
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,18 +2,28 @@ use std::{error::Error as Err, fmt};
 
 #[derive(Debug)]
 pub enum Error {
-    Io(std::io::Error),
+    /// The private_key field in the [Service Account Key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
+    /// is invalid and cannot be parsed
     #[cfg(feature = "jwt")]
     InvalidKeyFormat,
+    /// Unable to deserialize the base64 encoded RSA key
     Base64Decode(base64::DecodeError),
+    /// An error occurred trying to create an HTTP request
     Http(http::Error),
+    /// Failed to authenticate and retrieve an oauth token, and were unable to
+    /// deserialize a more exact reason from the error response
     HttpStatus(http::StatusCode),
+    /// Failed to de/serialize JSON
     Json(serde_json::Error),
+    /// Failed to authenticate and retrieve an oauth token
     Auth(AuthError),
+    /// The RSA key seems valid, but is unable to sign a payload
     #[cfg(feature = "jwt")]
     InvalidRsaKey(ring::error::Unspecified),
+    /// The RSA key is invalid and cannot be used to sign
     #[cfg(feature = "jwt")]
     InvalidRsaKeyRejected(ring::error::KeyRejected),
+    /// A mutex has been poisoned due to a panic while a lock was held
     Poisoned,
 }
 
@@ -23,7 +33,6 @@ impl fmt::Display for Error {
         use Error::*;
 
         match self {
-            Io(err) => write!(f, "{}", err),
             #[cfg(feature = "jwt")]
             InvalidKeyFormat => f.write_str("The key format is invalid or unknown"),
             Base64Decode(err) => write!(f, "{}", err),
@@ -42,10 +51,9 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn Err> {
-        use Error::{Auth, Base64Decode, Http, Io, Json};
+        use Error::{Auth, Base64Decode, Http, Json};
 
         match self {
-            Io(err) => Some(err as &dyn Err),
             Base64Decode(err) => Some(err as &dyn Err),
             Http(err) => Some(err as &dyn Err),
             Json(err) => Some(err as &dyn Err),
@@ -55,10 +63,9 @@ impl std::error::Error for Error {
     }
 
     fn source(&self) -> Option<&(dyn Err + 'static)> {
-        use Error::{Auth, Base64Decode, Http, Io, Json};
+        use Error::{Auth, Base64Decode, Http, Json};
 
         match self {
-            Io(err) => Some(err as &dyn Err),
             Base64Decode(err) => Some(err as &dyn Err),
             Http(err) => Some(err as &dyn Err),
             Json(err) => Some(err as &dyn Err),

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     InvalidRsaKey(ring::error::Unspecified),
     #[cfg(feature = "jwt")]
     InvalidRsaKeyRejected(ring::error::KeyRejected),
+    Poisoned,
 }
 
 impl fmt::Display for Error {
@@ -34,6 +35,7 @@ impl fmt::Display for Error {
             InvalidRsaKey(_err) => f.write_str("RSA key is invalid"),
             #[cfg(feature = "jwt")]
             InvalidRsaKeyRejected(err) => write!(f, "RSA key is invalid: {}", err),
+            Poisoned => f.write_str("A mutex is poisoned"),
         }
     }
 }

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -124,7 +124,7 @@ impl ServiceAccountAccess {
         let (hash, scopes) = Self::serialize_scopes(scopes.into_iter());
 
         let reason = {
-            let cache = self.cache.lock().map_err(|_| Error::Poisoned)?;
+            let cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
             match cache.binary_search_by(|i| i.hash.cmp(&hash)) {
                 Ok(i) => {
                     let token = &cache[i].token;
@@ -217,7 +217,7 @@ impl ServiceAccountAccess {
 
         // Last token wins, which...should?...be fine
         {
-            let mut cache = self.cache.lock().map_err(|_| Error::Poisoned)?;
+            let mut cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
             match cache.binary_search_by(|i| i.hash.cmp(&hash)) {
                 Ok(i) => cache[i].token = token.clone(),
                 Err(i) => {

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -12,8 +12,7 @@ pub mod prelude {
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
-/// Minimal parts needed from a GCP service acccount key
-/// for token acquisition
+/// Minimal parts needed from a GCP service acccount key for token acquisition
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct ServiceAccountInfo {
     /// The private key we use to sign
@@ -25,9 +24,8 @@ pub struct ServiceAccountInfo {
 }
 
 impl ServiceAccountInfo {
-    /// Deserializes service account from a byte slice. This data
-    /// is typically acquired by reading a service account JSON file
-    /// from disk
+    /// Deserializes service account from a byte slice. This data is typically
+    /// acquired by reading a service account JSON file from disk
     pub fn deserialize<T>(key_data: T) -> Result<Self, Error>
     where
         T: AsRef<[u8]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,12 @@
 //! * There are several other oauth crates available that have many more features and are easier
 //! to work with, if you don't care about what HTTP clients they use.
 //! * This crate requires more boilerplate to work with
+//! ## Features
+//!
+//! * `gcp` (default) - Support for [GCP oauth2](https://developers.google.com/identity/protocols/oauth2)
+//! * `wasm-web` - Enables wasm features in `chrono` and `ring` needed for `tame-oauth` to be used in a wasm browser context. Note this feature should not be used when targetting wasm outside the browser context, in which case you would likely need to target `wasm32-wasi`.
+//! * `jwt` (default) - Support for [JSON Web Tokens](https://jwt.io/), required for `gcp`
+//! * `url` (default) - Url parsing, required for `gcp`
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
This replaces the use of `parking_lot::Mutex` with just plain `std::sync::Mutex` due to https://github.com/Amanieu/parking_lot/issues/269, as honestly the use of `parking_lot` was a bit of overkill here anyways.

This also introduces a `wasm-web` feature that can be enabled to enable additional features in chrono and ring to allow tame-oauth to function a wasm web (browser) context. We don't assume the user is in a web context based on targetting wasm32-unknown-unknown, hence the feature.

Resolves: #36 