### PR TITLE
`ServiceAccountAccess::get_token_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+
+- `ServiceAccountAccess::get_token_with` for control over the JWT subject field.
+
 ## [0.5.1] - 2021-06-05
 ### Removed
 - Removed unused depdendency on `lock_api`, which was lingering after [PR#21](https://github.com/EmbarkStudios/tame-oauth/pull/21).

--- a/src/gcp/jwt.rs
+++ b/src/gcp/jwt.rs
@@ -12,7 +12,8 @@ pub(crate) struct Claims {
     pub(crate) expiration: i64,
     #[serde(rename = "iat")]
     pub(crate) issued_at: i64,
-    pub(crate) sub: Option<String>,
+    #[serde(rename = "sub")]
+    pub(crate) subject: Option<String>,
     pub(crate) scope: String,
 }
 

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -114,17 +114,18 @@ impl ServiceAccountAccess {
     ///
     /// Note that the scopes are not sorted or in any other way manipulated, so any
     /// modifications to them will require a new token to be requested.
+    #[inline]
     pub fn get_token<'a, S, I>(&self, scopes: I) -> Result<TokenOrRequest, Error>
     where
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
     {
-        self.get_token_with::<S, I, String>(None, scopes)
+        self.get_token_with_subject::<S, I, String>(None, scopes)
     }
 
     /// Like [`ServiceAccountAccess::get_token`], but allows the JWT "subject"
     /// to be passed in.
-    pub fn get_token_with<'a, S, I, T>(
+    pub fn get_token_with_subject<'a, S, I, T>(
         &self,
         subject: Option<T>,
         scopes: I,

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -119,18 +119,20 @@ impl ServiceAccountAccess {
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
     {
-        self.get_token_with(None, scopes)
+        self.get_token_with::<S, I, String>(None, scopes)
     }
 
-    /// Like [`get_token`], but allows the JWT "subject" to be passed in.
-    pub fn get_token_with<'a, S, I>(
+    /// Like [`ServiceAccountAccess::get_token`], but allows the JWT "subject"
+    /// to be passed in.
+    pub fn get_token_with<'a, S, I, T>(
         &self,
-        subject: Option<String>,
+        subject: Option<T>,
         scopes: I,
     ) -> Result<TokenOrRequest, Error>
     where
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
+        T: Into<String>,
     {
         let (hash, scopes) = Self::serialize_scopes(scopes.into_iter());
 
@@ -159,7 +161,7 @@ impl ServiceAccountAccess {
             audience: self.info.token_uri.clone(),
             expiration: expiry,
             issued_at: issued,
-            subject,
+            subject: subject.map(|s| s.into()),
         };
 
         let assertion = jwt::encode(

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -119,6 +119,19 @@ impl ServiceAccountAccess {
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
     {
+        self.get_token_with(None, scopes)
+    }
+
+    /// Like [`get_token`], but allows the JWT "subject" to be passed in.
+    pub fn get_token_with<'a, S, I>(
+        &self,
+        subject: Option<String>,
+        scopes: I,
+    ) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S>,
+    {
         let (hash, scopes) = Self::serialize_scopes(scopes.into_iter());
 
         let reason = {
@@ -146,7 +159,7 @@ impl ServiceAccountAccess {
             audience: self.info.token_uri.clone(),
             expiration: expiry,
             issued_at: issued,
-            sub: None,
+            subject,
         };
 
         let assertion = jwt::encode(


### PR DESCRIPTION
This PR exposes the new method `get_token_with` for control over the JWT "subject" field. This is necessary when interacting with the Gmail API via a Service Account, since Google requires that the **email address of the person you want to fetch emails for (etc) be included in the token creation process**. 

This PR has been tested and solves the "Failed precondition check" problem that has plagued a number of people over the years.

**Note:** Looking at the code, it seems to me that `Token` caching won't work correctly if different tokens have been fetched via `get_token_with`, since cache collision is based on the Access Scopes only. This should probably be considered a bug, and perhaps fixed in this PR. Thoughts?