### PR TITLE
Add support for GCP MetadataServer token providers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -96,9 +96,9 @@ impl From<serde_json::Error> for Error {
 #[derive(serde::Deserialize, Debug)]
 pub struct AuthError {
     /// Top level error type
-    error: Option<String>,
+    pub error: Option<String>,
     /// More specific details on the error
-    error_description: Option<String>,
+    pub error_description: Option<String>,
 }
 
 impl fmt::Display for AuthError {

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{self, Error},
+    error::{self, AuthError, Error},
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
 };
 
@@ -7,7 +7,7 @@ mod jwt;
 use jwt::{Algorithm, Header, Key};
 
 pub mod prelude {
-    pub use super::{ServiceAccountAccess, ServiceAccountInfo};
+    pub use super::{MetadataServerProvider, ServiceAccountAccess, ServiceAccountInfo};
     pub use crate::token::{Token, TokenOrRequest, TokenProvider};
 }
 
@@ -48,6 +48,22 @@ pub struct ServiceAccountAccess {
     info: ServiceAccountInfo,
     priv_key: Vec<u8>,
     cache: std::sync::Mutex<Vec<Entry>>,
+}
+
+pub struct MetadataServerProvider {
+    account_name: String,
+}
+
+/// Both the `ServiceAccountAccess` and `MetadataServerProvider` get
+/// back JSON responses with this schema from their endpoints.
+#[derive(serde::Deserialize, Debug)]
+struct TokenResponse {
+    /// The actual token
+    access_token: String,
+    /// The token type, pretty much always Header
+    token_type: String,
+    /// The time until the token expires and a new one needs to be requested
+    expires_in: i64,
 }
 
 impl ServiceAccountAccess {
@@ -101,17 +117,6 @@ impl ServiceAccountAccess {
 
         (hash, scopes)
     }
-}
-
-/// This is the schema of the server's response.
-#[derive(serde::Deserialize, Debug)]
-struct TokenResponse {
-    /// The actual token
-    access_token: String,
-    /// The token type, pretty much always Header
-    token_type: String,
-    /// The time until the token expires and a new one needs to be requested
-    expires_in: i64,
 }
 
 impl TokenProvider for ServiceAccountAccess {
@@ -242,6 +247,103 @@ impl TokenProvider for ServiceAccountAccess {
     }
 }
 
+impl MetadataServerProvider {
+    pub fn new(account_name: Option<String>) -> Self {
+        if let Some(name) = account_name {
+            Self { account_name: name }
+        } else {
+            // GCP uses "default" as the name in URIs.
+            Self {
+                account_name: "default".to_string(),
+            }
+        }
+    }
+}
+
+impl TokenProvider for MetadataServerProvider {
+    fn get_token_with_subject<'a, S, I, T>(
+        &self,
+        subject: Option<T>,
+        scopes: I,
+    ) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S>,
+        T: Into<String>,
+    {
+        // We can only support subject being none
+        if subject.is_some() {
+            return Err(Error::Auth(AuthError {
+                error: Some("Unsupported".to_string()),
+                error_description: Some(
+                    "Metadata server tokens do not support jwt subjects".to_string(),
+                ),
+            }));
+        }
+
+        // Regardless of GCE or GAE, the token_uri is
+        // computeMetadata/v1/instance/service-accounts/<name or
+        // id>/token.
+        let mut url = format!(
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{}/token",
+            self.account_name
+        );
+
+        // Merge all the scopes into a single string.
+        let scopes_str = scopes
+            .into_iter()
+            .map(|s| s.as_ref())
+            .collect::<Vec<&str>>()
+            .join(",");
+
+        // If we have any scopes, pass them along in the querystring.
+        if !scopes_str.is_empty() {
+            url.push_str("?scopes=");
+            url.push_str(&scopes_str);
+        }
+
+        // Make an empty body, but as Vec<u8> to match the request in
+        // TokenOrRequest.
+        let empty_body: Vec<u8> = vec![];
+
+        let request = http::Request::builder()
+            .method("GET")
+            .uri(url)
+            // To get responses from GCE, we must pass along the
+            // Metadata-Flavor header with a value of "Google".
+            .header("Metadata-Flavor", "Google")
+            .body(empty_body)?;
+
+        Ok(TokenOrRequest::Request {
+            request,
+            reason: RequestReason::ScopesChanged,
+            scope_hash: 0,
+        })
+    }
+
+    fn parse_token_response<S>(
+        &self,
+        _hash: u64,
+        response: http::Response<S>,
+    ) -> Result<Token, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let (parts, body) = response.into_parts();
+
+        if !parts.status.is_success() {
+            return Err(Error::HttpStatus(parts.status));
+        }
+
+        // Deserialize our response, or fail.
+        let token_res: TokenResponse = serde_json::from_slice(body.as_ref())?;
+
+        // Convert it into our output.
+        let token: Token = token_res.into();
+        Ok(token)
+    }
+}
+
 impl From<TokenResponse> for Token {
     fn from(tr: TokenResponse) -> Self {
         let expires_ts = chrono::Utc::now().timestamp() + tr.expires_in;
@@ -289,5 +391,56 @@ mod test {
 
         assert_eq!(expected, hash);
         assert_eq!("scope1 scope2 scope3", scopes);
+    }
+
+    #[test]
+    fn metadata_noscopes() {
+        let provider = MetadataServerProvider::new(None);
+
+        let scopes: Vec<&str> = vec![];
+
+        let token_or_req = provider
+            .get_token(&scopes)
+            .expect("Should have gotten a request");
+
+        match token_or_req {
+            TokenOrRequest::Token(_) => panic!("Shouldn't have gotten a token"),
+            TokenOrRequest::Request { request, .. } => {
+                // Should be the metadata server
+                assert_eq!(request.uri().host(), Some("metadata.google.internal"));
+                // Since we had no scopes, no querystring.
+                assert_eq!(request.uri().query(), None);
+            }
+        }
+    }
+
+    #[test]
+    fn metadata_with_scopes() {
+        let provider = MetadataServerProvider::new(None);
+
+        let scopes: Vec<&str> = vec!["scope1", "scope2"];
+
+        let token_or_req = provider
+            .get_token(&scopes)
+            .expect("Should have gotten a request");
+
+        match token_or_req {
+            TokenOrRequest::Token(_) => panic!("Shouldn't have gotten a token"),
+            TokenOrRequest::Request { request, .. } => {
+                // Should be the metadata server
+                assert_eq!(request.uri().host(), Some("metadata.google.internal"));
+                // Since we had some scopes, we should have a querystring.
+                assert!(request.uri().query().is_some());
+
+                let query_string = request.uri().query().unwrap();
+                // We don't care about ordering, but the query_string
+                // should be comma-separated and only include the
+                // scopes.
+                assert!(
+                    query_string == "scopes=scope1,scope2"
+                        || query_string == "scopes=scope2,scope1"
+                );
+            }
+        }
     }
 }

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -1,13 +1,14 @@
 use crate::{
     error::{self, Error},
-    token::Token,
+    token::{RequestReason, Token, TokenOrRequest},
 };
 
 mod jwt;
 use jwt::{Algorithm, Header, Key};
 
 pub mod prelude {
-    pub use super::{RequestReason, ServiceAccountAccess, ServiceAccountInfo, TokenOrRequest};
+    pub use super::{ServiceAccountAccess, ServiceAccountInfo};
+    pub use crate::token::{Token, TokenOrRequest};
 }
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -40,32 +41,6 @@ impl ServiceAccountInfo {
 struct Entry {
     hash: u64,
     token: Token,
-}
-
-#[derive(Debug)]
-pub enum RequestReason {
-    /// An existing token has expired
-    Expired,
-    /// The requested scopes have never been seen before
-    ScopesChanged,
-}
-
-/// Either a valid token, or an HTTP request that
-/// can be used to acquire one
-#[derive(Debug)]
-pub enum TokenOrRequest {
-    /// A valid token that can be supplied in an API request
-    Token(Token),
-    Request {
-        /// The parts of an HTTP request that must be sent
-        /// to acquire the token, in the client of your choice
-        request: http::Request<Vec<u8>>,
-        /// The reason we need to retrieve a new token
-        reason: RequestReason,
-        /// An opaque hash of the scope(s) for which the request
-        /// was constructed
-        scope_hash: u64,
-    },
 }
 
 /// A token provider for a GCP service account.

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use chrono::{offset::TimeZone, DateTime, Utc};
 
 /// Represents a token as returned by `OAuth2` servers.
@@ -67,6 +68,49 @@ pub enum TokenOrRequest {
         /// was constructed
         scope_hash: u64,
     },
+}
+
+/// A `TokenProvider` has a single method to implement
+/// `get_token_with_subject`. Implementations are free to perform
+/// caching or always return a `Request` in the `TokenOrRequest`.
+pub trait TokenProvider {
+    /// Attempts to retrieve a token that can be used in an API request, if we haven't
+    /// already retrieved a token for the specified scopes, or the token has expired,
+    /// an HTTP request is returned that can be used to retrieve a token.
+    ///
+    /// Note that the scopes are not sorted or in any other way manipulated, so any
+    /// modifications to them will require a new token to be requested.
+    #[inline]
+    fn get_token<'a, S, I>(&self, scopes: I) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S>,
+    {
+        self.get_token_with_subject::<S, I, String>(None, scopes)
+    }
+
+    /// Like [`TokenProvider::get_token`], but allows the JWT "subject"
+    /// to be passed in.
+    fn get_token_with_subject<'a, S, I, T>(
+        &self,
+        subject: Option<T>,
+        scopes: I,
+    ) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S>,
+        T: Into<String>;
+
+    /// Once a response has been received for a token request, call
+    /// this method to deserialize the token (and potentially store it
+    /// in a local cache for reuse until it expires).
+    fn parse_token_response<S>(
+        &self,
+        hash: u64,
+        response: http::Response<S>,
+    ) -> Result<Token, Error>
+    where
+        S: AsRef<[u8]>;
 }
 
 impl std::convert::TryInto<http::header::HeaderValue> for Token {

--- a/src/token.rs
+++ b/src/token.rs
@@ -43,6 +43,32 @@ impl Token {
     }
 }
 
+#[derive(Debug)]
+pub enum RequestReason {
+    /// An existing token has expired
+    Expired,
+    /// The requested scopes have never been seen before
+    ScopesChanged,
+}
+
+/// Either a valid token, or an HTTP request that
+/// can be used to acquire one
+#[derive(Debug)]
+pub enum TokenOrRequest {
+    /// A valid token that can be supplied in an API request
+    Token(Token),
+    Request {
+        /// The parts of an HTTP request that must be sent
+        /// to acquire the token, in the client of your choice
+        request: http::Request<Vec<u8>>,
+        /// The reason we need to retrieve a new token
+        reason: RequestReason,
+        /// An opaque hash of the scope(s) for which the request
+        /// was constructed
+        scope_hash: u64,
+    },
+}
+
 impl std::convert::TryInto<http::header::HeaderValue> for Token {
     type Error = crate::Error;
 


### PR DESCRIPTION
Hello! First time caller, long-time listener.

Like issue #39, I wanted to support "get a token from the metadata server" in gcsfuser [1]. This way, users don't have to export their service account keys (which is a security risk if your key file is misplaced).

I'm new-ish to Rust, so I tried to make this fairly minimal, but I'd be happy to redo whatever you folks suggest. In particular, using TokenProvider as a trait is a bit awkward, since `get_token` and `parse_token_response` are both templated (and so callers can't just hold TokenProvider or dyn TokenProvider or anything like that).

In my usage in gcsfuser, I changed my auth.rs like so to "simulate" the kind of dispatch I wanted, which is kind of sad:

```
diff --git a/src/auth.rs b/src/auth.rs
index cdef757..2754129 100644
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -21,16 +21,24 @@ use tame_oauth::gcp::prelude::*;
 
 use crate::errors::HttpError;
 
+enum TokenProviderWrapper {
+    Metadata(MetadataServerProvider),
+    ServiceAccount(ServiceAccountAccess),
+}
+
 lazy_static! {
-    static ref TOKEN_PROVIDER: Option<ServiceAccountAccess> = {
+    static ref TOKEN_PROVIDER: Option<TokenProviderWrapper> = {
     // Read in the usual key file.
     let env_key = "GOOGLE_APPLICATION_CREDENTIALS";
     let cred_env = std::env::var(env_key);
     let cred_path = match cred_env {
         Ok(path) => path,
         Err(std::env::VarError::NotPresent) => {
-        info!("{} not set. Assuming public buckets", env_key);
-        return None
+        // If we're on GCP, use the Metadata server
+        debug!("Going to use the metadata server");
+        return Some(TokenProviderWrapper::Metadata(MetadataServerProvider::new(None)));
+            //info!("{} not set. Assuming public buckets", env_key);
+            //return None;
         },
         Err(error) => panic!("Invalid {}. Error {:?}", env_key, error)
     };
@@ -40,7 +48,7 @@ lazy_static! {
     let key_data = std::fs::read_to_string(cred_path).expect("failed to read credential file");
     let acct_info = ServiceAccountInfo::deserialize(key_data).expect("failed to decode credential file");
 
-    Some(ServiceAccountAccess::new(acct_info).expect("failed to create OAuth Token Provider"))
+    Some(TokenProviderWrapper::ServiceAccount(ServiceAccountAccess::new(acct_info).expect("failed to create OAuth Token Provider")))
     };
 }
 
@@ -49,8 +57,8 @@ lazy_static! {
 async fn do_http_request(
     request: http::Request<Vec<u8>>,
 ) -> Result<http::Response<Vec<u8>>, HttpError> {
-    // We only expect a POST.
-    assert_eq!(request.method(), http::Method::POST);
+    // We only expect a GET (metadata server) or POST (service account oauth token).
+    assert!(request.method() == http::Method::POST || request.method() == http::Method::GET);
 
     let https = hyper_rustls::HttpsConnector::with_native_roots();
     let client = hyper::Client::builder().build::<_, hyper::Body>(https);
@@ -79,9 +87,12 @@ async fn get_token() -> Result<Option<String>, HttpError> {
         return Ok(None);
     }
 
-    let provider = TOKEN_PROVIDER.as_ref().unwrap();
+    let wrapper = TOKEN_PROVIDER.as_ref().unwrap();
 
-    let token_or_req = provider.get_token(&scopes).unwrap();
+    let token_or_req = match wrapper {
+        TokenProviderWrapper::Metadata(x) => x.get_token(&scopes).unwrap(),
+        TokenProviderWrapper::ServiceAccount(x) => x.get_token(&scopes).unwrap(),
+    };
 
     let token = match token_or_req {
         TokenOrRequest::Request {
@@ -92,7 +103,14 @@ async fn get_token() -> Result<Option<String>, HttpError> {
             let response = do_http_request(request).await?;
 
             // Parse and unwrap the token.
-            provider.parse_token_response(scope_hash, response).unwrap()
+            match wrapper {
+                TokenProviderWrapper::Metadata(x) => {
+                    x.parse_token_response(scope_hash, response).unwrap()
+                }
+                TokenProviderWrapper::ServiceAccount(x) => {
+                    x.parse_token_response(scope_hash, response).unwrap()
+                }
+            }
         }
         TokenOrRequest::Token(token) => token,
     };
```

[1] https://github.com/GoogleCloudPlatform/gcsfuser