### PR TITLE
Cached token provider

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,10 +15,7 @@ deny = [
     { name = "openssl" },
     { name = "openssl-sys" },
 ]
-skip = [
-    # hyper uses this old version
-    { name = "itoa", version = "=0.4.8" },
-]
+skip = []
 skip-tree = []
 
 [licenses]
@@ -29,6 +26,7 @@ allow = [
     "Apache-2.0",
     "MIT",
     "BSD-3-Clause",
+    "Unicode-DFS-2016",
 ]
 exceptions = [
     { allow = ["MPL-2.0"], name = "webpki-roots" },

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -127,13 +127,15 @@ impl TokenProviderWrapper {
         if let Some(gcloud_file) = gcloud_config_file() {
             match read_to_string(&gcloud_file) {
                 Ok(json_data) => {
-                    let end_user_credentials = eu::EndUserCredentials::deserialize(json_data)
+                    let end_user_credentials = eu::EndUserCredentialsInfo::deserialize(json_data)
                         .map_err(|e| Error::InvalidCredentials {
-                            file: gcloud_file,
-                            error: Box::new(e),
-                        })?;
+                        file: gcloud_file,
+                        error: Box::new(e),
+                    })?;
 
-                    return Ok(Some(TokenProviderWrapper::EndUser(end_user_credentials)));
+                    return Ok(Some(TokenProviderWrapper::EndUser(
+                        eu::EndUserCredentials::new(end_user_credentials),
+                    )));
                 }
                 // Skip not found errors, and fall back to the metadata server check
                 Err(nf) if nf.kind() == std::io::ErrorKind::NotFound => {}

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -18,11 +18,6 @@ pub use {
     sa::{ServiceAccountInfo, ServiceAccountProvider},
 };
 
-struct Entry {
-    hash: u64,
-    token: Token,
-}
-
 /// Both the [`ServiceAccountProvider`] and [`MetadataServerProvider`] get back
 /// JSON responses with this schema from their endpoints.
 #[derive(serde::Deserialize, Debug)]
@@ -190,7 +185,7 @@ impl TokenProvider for TokenProviderWrapper {
     ) -> Result<TokenOrRequest, Error>
     where
         S: AsRef<str> + 'a,
-        I: IntoIterator<Item = &'a S>,
+        I: IntoIterator<Item = &'a S> + Clone,
         T: Into<String>,
     {
         match self {

--- a/src/gcp/end_user.rs
+++ b/src/gcp/end_user.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Provides tokens using
 /// [default application credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default)
-/// Caches token internally.
+/// Caches tokens internally.
 pub type EndUserCredentials = CachedTokenProvider<EndUserCredentialsInner>;
 impl EndUserCredentials {
     pub fn deserialize<T>(key_data: T) -> Result<Self, Error>

--- a/src/gcp/metadata_server.rs
+++ b/src/gcp/metadata_server.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// [Provides tokens](https://cloud.google.com/compute/docs/instances/verifying-instance-identity)
 /// using the metadata server accessible when running from within GCP.
-/// Internally caching the tokens.
+/// Caches tokens internally.
 pub type MetadataServerProvider = CachedTokenProvider<MetadataServerProviderInner>;
 impl MetadataServerProvider {
     pub fn new(account_name: Option<String>) -> Self {

--- a/src/gcp/metadata_server.rs
+++ b/src/gcp/metadata_server.rs
@@ -2,15 +2,26 @@ use super::TokenResponse;
 use crate::{
     error::{self, Error},
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
+    token_cache::CachedTokenProvider,
 };
 
 /// [Provides tokens](https://cloud.google.com/compute/docs/instances/verifying-instance-identity)
+/// using the metadata server accessible when running from within GCP.
+/// Internally caching the tokens.
+pub type MetadataServerProvider = CachedTokenProvider<MetadataServerProviderInner>;
+impl MetadataServerProvider {
+    pub fn new(account_name: Option<String>) -> Self {
+        CachedTokenProvider::wrap(MetadataServerProviderInner::new(account_name))
+    }
+}
+
+/// [Provides tokens](https://cloud.google.com/compute/docs/instances/verifying-instance-identity)
 /// using the metadata server accessible when running from within GCP
-pub struct MetadataServerProvider {
+pub struct MetadataServerProviderInner {
     account_name: String,
 }
 
-impl MetadataServerProvider {
+impl MetadataServerProviderInner {
     pub fn new(account_name: Option<String>) -> Self {
         Self {
             account_name: account_name.unwrap_or_else(|| "default".into()),
@@ -18,7 +29,7 @@ impl MetadataServerProvider {
     }
 }
 
-impl TokenProvider for MetadataServerProvider {
+impl TokenProvider for MetadataServerProviderInner {
     fn get_token_with_subject<'a, S, I, T>(
         &self,
         subject: Option<T>,

--- a/src/gcp/service_account.rs
+++ b/src/gcp/service_account.rs
@@ -35,7 +35,8 @@ impl ServiceAccountInfo {
     }
 }
 
-/// A token provider for a GCP service account that caches the tokens.
+/// A token provider for a GCP service account.
+/// Caches tokens internally.
 pub type ServiceAccountProvider = CachedTokenProvider<ServiceAccountProviderInner>;
 impl ServiceAccountProvider {
     pub fn new(info: ServiceAccountInfo) -> Result<Self, Error> {

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -19,7 +19,7 @@ pub(crate) struct Claims {
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
-#[derive(Debug, Clone, PartialEq, Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct Header {
     /// The type of JWS: it can only be "JWT" here
     ///
@@ -80,7 +80,7 @@ impl Default for Header {
 }
 
 /// The algorithms supported for signing/verifying
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, serde::Deserialize)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Algorithm {
     /// HMAC using SHA-256
@@ -177,7 +177,7 @@ pub fn encode<T: Serialize>(header: &Header, claims: &T, key: Key<'_>) -> Result
     let encoded_header = to_jwt_part(&header)?;
     let encoded_claims = to_jwt_part(&claims)?;
     let signing_input = [encoded_header.as_ref(), encoded_claims.as_ref()].join(".");
-    let signature = sign(&*signing_input, key, header.alg)?;
+    let signature = sign(&signing_input, key, header.alg)?;
 
     Ok([signing_input, signature].join("."))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,5 +86,6 @@ mod jwt;
 
 mod error;
 mod token;
+mod token_cache;
 
 pub use crate::{error::Error, token::Token};

--- a/src/token.rs
+++ b/src/token.rs
@@ -80,7 +80,7 @@ pub trait TokenProvider {
     fn get_token<'a, S, I>(&self, scopes: I) -> Result<TokenOrRequest, Error>
     where
         S: AsRef<str> + 'a,
-        I: IntoIterator<Item = &'a S>,
+        I: IntoIterator<Item = &'a S> + Clone,
     {
         self.get_token_with_subject::<S, I, String>(None, scopes)
     }
@@ -95,7 +95,7 @@ pub trait TokenProvider {
     ) -> Result<TokenOrRequest, Error>
     where
         S: AsRef<str> + 'a,
-        I: IntoIterator<Item = &'a S>,
+        I: IntoIterator<Item = &'a S> + Clone,
         T: Into<String>;
 
     /// Once a response has been received for a token request, call this method

--- a/src/token.rs
+++ b/src/token.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 /// replies, as well as for serialization for later reuse. This is the reason
 /// for the two fields dealing with expiry - once in relative in and once in
 /// absolute terms.
-#[derive(Clone, PartialEq, Debug, serde::Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, serde::Deserialize)]
 pub struct Token {
     /// used when authenticating calls to oauth2 enabled services.
     pub access_token: String,

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -11,6 +11,7 @@ struct Entry {
     token: Token,
 }
 
+/// An in-memory cache for caching tokens.
 pub struct TokenCache {
     cache: Mutex<Vec<Entry>>,
 }
@@ -27,6 +28,7 @@ impl TokenCache {
         }
     }
 
+    /// Get a token from the cache that matches the hash
     pub fn get(&self, hash: Hash) -> Result<TokenOrRequestReason, Error> {
         let reason = {
             let cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
@@ -47,6 +49,7 @@ impl TokenCache {
         Ok(TokenOrRequestReason::RequestReason(reason))
     }
 
+    /// Insert a token into the cache
     pub fn insert(&self, token: Token, hash: Hash) -> Result<(), Error> {
         // Last token wins, which...should?...be fine
         let mut cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
@@ -61,6 +64,8 @@ impl TokenCache {
     }
 }
 
+/// Wraps a `TokenProvider` in a cache, only invokes the inner `TokenProvider` if
+/// the token in cache is expired, or if it doesn't exsist.
 pub struct CachedTokenProvider<P> {
     cache: TokenCache,
     inner: P,

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,0 +1,137 @@
+use crate::token::{TokenOrRequest, TokenProvider};
+use crate::{error::Error, token::RequestReason, Token};
+
+use std::hash::Hasher;
+use std::sync::Mutex;
+
+type Hash = u64;
+
+struct Entry {
+    hash: Hash,
+    token: Token,
+}
+
+pub(crate) struct TokenCache {
+    cache: Mutex<Vec<Entry>>,
+}
+
+pub enum TokenOrRequestReason {
+    Token(Token),
+    RequestReason(RequestReason),
+}
+
+impl TokenCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn get(&self, hash: Hash) -> Result<TokenOrRequestReason, Error> {
+        let reason = {
+            let cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
+            match cache.binary_search_by(|i| i.hash.cmp(&hash)) {
+                Ok(i) => {
+                    let token = &cache[i].token;
+
+                    if !token.has_expired() {
+                        return Ok(TokenOrRequestReason::Token(token.clone()));
+                    }
+
+                    RequestReason::Expired
+                }
+                Err(_) => RequestReason::ScopesChanged,
+            }
+        };
+
+        Ok(TokenOrRequestReason::RequestReason(reason))
+    }
+
+    pub fn insert(&self, token: Token, hash: Hash) -> Result<(), Error> {
+        // Last token wins, which...should?...be fine
+        let mut cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
+        match cache.binary_search_by(|i| i.hash.cmp(&hash)) {
+            Ok(i) => cache[i].token = token.clone(),
+            Err(i) => {
+                cache.insert(i, Entry { hash, token });
+            }
+        };
+
+        Ok(())
+    }
+}
+
+struct CachedTokenProvider<P> {
+    cache: TokenCache,
+    inner: P,
+}
+
+impl<P> CachedTokenProvider<P> {
+    pub fn new(token_provider: P) -> Self {
+        Self {
+            cache: TokenCache::new(),
+            inner: token_provider,
+        }
+    }
+}
+
+impl<P> TokenProvider for CachedTokenProvider<P>
+where
+    P: TokenProvider,
+{
+    fn get_token_with_subject<'a, S, I, T>(
+        &self,
+        subject: Option<T>,
+        scopes: I,
+    ) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S> + Clone,
+        T: Into<String>,
+    {
+        let hash = {
+            let scopes_str = scopes
+                .clone()
+                .into_iter()
+                .map(|s| s.clone().as_ref())
+                .collect::<Vec<_>>()
+                .join("|");
+
+            let hash = {
+                let mut hasher = twox_hash::XxHash::default();
+                hasher.write(scopes_str.as_bytes());
+                hasher.finish()
+            };
+
+            hash
+        };
+
+        let reason = match self.cache.get(hash)? {
+            TokenOrRequestReason::Token(token) => return Ok(TokenOrRequest::Token(token)),
+            TokenOrRequestReason::RequestReason(reason) => reason,
+        };
+
+        match self.inner.get_token_with_subject(subject, scopes)? {
+            TokenOrRequest::Token(token) => Ok(TokenOrRequest::Token(token)),
+            TokenOrRequest::Request { request, .. } => Ok(TokenOrRequest::Request {
+                request,
+                reason,
+                scope_hash: hash,
+            }),
+        }
+    }
+
+    fn parse_token_response<S>(
+        &self,
+        hash: u64,
+        response: http::Response<S>,
+    ) -> Result<Token, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let token = self.inner.parse_token_response(hash, response)?;
+
+        self.cache.insert(token.clone(), hash)?;
+        Ok(token)
+    }
+}

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -51,7 +51,7 @@ impl TokenCache {
         // Last token wins, which...should?...be fine
         let mut cache = self.cache.lock().map_err(|_e| Error::Poisoned)?;
         match cache.binary_search_by(|i| i.hash.cmp(&hash)) {
-            Ok(i) => cache[i].token = token.clone(),
+            Ok(i) => cache[i].token = token,
             Err(i) => {
                 cache.insert(i, Entry { hash, token });
             }
@@ -129,7 +129,7 @@ where
     let scopes_str = scopes
         .clone()
         .into_iter()
-        .map(|s| s.clone().as_ref())
+        .map(|s| s.as_ref())
         .collect::<Vec<_>>()
         .join("|");
 


### PR DESCRIPTION
Moves the caching out of `ServiceAccountProvider` so that it can be use by all token providers.

This also implements a cached token provider that can be used to wrap token providers.
Not sure if there is a more idiomatic way to do the wrapping?

I should also add some tests for the caching, will do so next week, but happy to take some feedback on this.

Fixes #45