### PR TITLE
Add id token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0] - 2023-01-10
 ### Changed
-- [PR#51](https://github.com/EmbarkStudios/tame-oauth/pull/51) moved the token cache out of `ServiceAccountProvider` into a public type, and added a cached token provider that can wrap any other token provider. This wrapper now wrapps all the current gcp token providers, making them cached by default.
+- [PR#51](https://github.com/EmbarkStudios/tame-oauth/pull/51) moved the token cache out of `ServiceAccountProvider` into a public type, and added a cached token provider that can wrap any other token provider. This wrapper now wraps all the current gcp token providers, making them cached by default.
 - [PR#53](https://github.com/EmbarkStudios/tame-oauth/pull/53) changed the cache lock from a Mutex into a RwLock.
 
 ## [0.7.0] - 2022-02-02

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Feature requests will be tagged as `enhancement` and their status will be update
 
 ### Bugs
 
-When reporting a bug or unexpected behaviour in a project, make sure your issue descibes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
+When reporting a bug or unexpected behaviour in a project, make sure your issue describes steps to reproduce the behaviour, including the platform you were using, what steps you took, and any error messages.
 
 Reproducible bugs will be tagged as `bug` and their status will be updated in the comments of the issue.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ features = ["rustls-tls"]
 [dev-dependencies.tokio]
 version = "1.0"
 features = ["macros", "rt-multi-thread"]
+
+[dev-dependencies.bytes]
+version = "1.4"

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,9 @@ skip = [
     # reqwest uses old dependency (dev dependency)
     { name = "base64", version = "=0.13.1" }
 ]
-skip-tree = []
+skip-tree = [
+    { name = "windows-sys", version = "=0.42" },
+]
 
 [licenses]
 unlicensed = "deny"

--- a/examples/default_creds_id_token.rs
+++ b/examples/default_creds_id_token.rs
@@ -8,8 +8,6 @@ use tame_oauth::gcp::*;
 // token hasn't expired
 #[tokio::main]
 async fn main() {
-    let scopes: Vec<_> = std::env::args().skip(1).collect();
-
     let provider = TokenProviderWrapper::get_default_provider()
         .expect("unable to read default token provider")
         .expect("unable to find default token provider");
@@ -19,10 +17,10 @@ async fn main() {
     // Attempt to get a token, since we have never used this accessor
     // before, it's guaranteed that we will need to make an HTTPS
     // request to the token provider to retrieve a token. This
-    // will also happen if we want to get a token for a different set
-    // of scopes, or if the token has expired.
-    match provider.get_token(&scopes).unwrap() {
-        TokenOrRequest::Request {
+    // will also happen if we want to get a token for a different
+    // audience, or if the token has expired.
+    match provider.get_id_token("my-audience").unwrap() {
+        IDTokenOrRequest::IDTokenRequest {
             // This is an http::Request that we can use to build
             // a client request for whichever HTTP client implementation
             // you wish to use
@@ -69,11 +67,11 @@ async fn main() {
             let buffer = response.bytes().await.unwrap();
             let response = builder.body(buffer).unwrap();
 
-            provider
-                .parse_token_response(hash, response)
+            let _token = provider
+                .parse_id_token_response(hash, response)
                 .expect("invalid token response");
 
-            println!("cool, we were able to receive a token!");
+            println!("cool, we were able to receive a id token!");
         }
         _ => unreachable!(),
     }

--- a/examples/svc_account.rs
+++ b/examples/svc_account.rs
@@ -74,7 +74,7 @@ async fn main() {
             let buffer = response.bytes().await.unwrap();
             let response = builder.body(buffer).unwrap();
 
-            // Tell our accesssor about the response, also passing
+            // Tell our accessor about the response, also passing
             // the scope_hash for the scopes we initially requested,
             // this will allow future token requests for those scopes
             // to use a cached token, at least until it expires (~1 hour)

--- a/examples/svc_account.rs
+++ b/examples/svc_account.rs
@@ -32,7 +32,7 @@ async fn main() {
             // a client request for whichever HTTP client implementation
             // you wish to use
             request,
-            scope_hash,
+            hash,
             ..
         } => {
             let client = reqwest::Client::new();
@@ -78,9 +78,7 @@ async fn main() {
             // the scope_hash for the scopes we initially requested,
             // this will allow future token requests for those scopes
             // to use a cached token, at least until it expires (~1 hour)
-            sa_provider
-                .parse_token_response(scope_hash, response)
-                .unwrap()
+            sa_provider.parse_token_response(hash, response).unwrap()
         }
         _ => unreachable!(),
     };

--- a/examples/svc_account_id_token.rs
+++ b/examples/svc_account_id_token.rs
@@ -102,7 +102,6 @@ async fn execute_request(request: http::Request<Vec<u8>>) -> http::Response<Byte
     );
 
     let buffer = response.bytes().await.unwrap();
-    
 
     builder.body(buffer).unwrap()
 }

--- a/examples/svc_account_id_token.rs
+++ b/examples/svc_account_id_token.rs
@@ -1,0 +1,108 @@
+use tame_oauth::gcp::*;
+
+use bytes::Bytes;
+
+// This example shows the basics for creating a GCP service account token
+// provider and requesting a token from it. This particular example uses the
+// reqwest HTTP client, but the point of this crate is that you can use
+// whichever one you like as long as you don't mind doing a little bit of
+// boilerplate to convert between from http::Request and to http::Response
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+
+    let key_path = args
+        .next()
+        .expect("expected path to a service account json file");
+    let service_key = std::fs::read_to_string(key_path).expect("failed to read json key");
+
+    // Deserialize the service account info from the json data
+    let acct_info = ServiceAccountInfo::deserialize(service_key).unwrap();
+
+    // Create the token provider!
+    let sa_provider = ServiceAccountProvider::new(acct_info).unwrap();
+
+    let audience = "my-audience";
+
+    // Attempt to get a token, since we have never used this accessor
+    // before, it's guaranteed that we will need to make an HTTPS
+    // request to the token provider to retrieve a token. This
+    // will also happen if we want to get a token for a different
+    // audience, or if the token has expired.
+    let token = match sa_provider.get_id_token(audience).unwrap() {
+        IDTokenOrRequest::AccessTokenRequest { request, hash, .. } => {
+            let access_token_response = execute_request(request).await;
+
+            let id_token_request = sa_provider
+                .get_id_token_with_access_token(audience, access_token_response)
+                .unwrap();
+
+            let id_token_response = execute_request(id_token_request).await;
+
+            sa_provider
+                .parse_id_token_response(hash, id_token_response)
+                .unwrap()
+        }
+        _ => unreachable!(),
+    };
+
+    // Uncomment this if you want to go to lunch and see an unreachable panic
+    // when you get back
+    // std::thread::sleep(std::time::Duration::from_secs(60 * 60))
+
+    // Retrieving a token for the same scopes for which a token has been acquired
+    // will use the cached token until it expires
+    match sa_provider.get_id_token(audience).unwrap() {
+        IDTokenOrRequest::IDToken(tk) => {
+            assert_eq!(tk, token);
+            println!(
+                "cool, you were able to retrieve a token with aud {}!",
+                audience,
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+async fn execute_request(request: http::Request<Vec<u8>>) -> http::Response<Bytes> {
+    let client = reqwest::Client::new();
+
+    let (parts, body) = request.into_parts();
+    let uri = parts.uri.to_string();
+
+    // This will always be a POST, but for completeness sake...
+    let builder = match parts.method {
+        http::Method::GET => client.get(&uri),
+        http::Method::POST => client.post(&uri),
+        http::Method::DELETE => client.delete(&uri),
+        http::Method::PUT => client.put(&uri),
+        method => unimplemented!("{} not implemented", method),
+    };
+
+    // Build the full request from the headers and body that were
+    // passed to you, without modifying them.
+    let request = builder.headers(parts.headers).body(body).build().unwrap();
+
+    // Send the actual request
+    let response = client.execute(request).await.unwrap();
+
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .version(response.version());
+
+    let headers = builder.headers_mut().unwrap();
+
+    // Unfortunately http doesn't expose a way to just use
+    // an existing HeaderMap, so we have to copy them :(
+    headers.extend(
+        response
+            .headers()
+            .into_iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+
+    let buffer = response.bytes().await.unwrap();
+    
+
+    builder.body(buffer).unwrap()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
         file: std::path::PathBuf,
         error: Box<Error>,
     },
-    /// An error occured due to [`SystemTime`](std::time::SystemTime)
+    /// An error occurred due to [`SystemTime`](std::time::SystemTime)
     SystemTime(std::time::SystemTimeError),
     /// Unable to parse the returned token
     InvalidTokenFormat,

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     },
     /// An error occured due to [`SystemTime`](std::time::SystemTime)
     SystemTime(std::time::SystemTimeError),
+    /// Unable to parse the returned token
+    InvalidTokenFormat,
 }
 
 impl fmt::Display for Error {
@@ -64,6 +66,9 @@ impl fmt::Display for Error {
             }
             SystemTime(te) => {
                 write!(f, "System Time error: {}", te)
+            }
+            InvalidTokenFormat => {
+                write!(f, "Invalid token format")
             }
         }
     }

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -11,6 +11,7 @@ use end_user as eu;
 use metadata_server as ms;
 use service_account as sa;
 
+pub use crate::id_token::{IDToken, IDTokenOrRequest, IDTokenProvider};
 pub use crate::token::{Token, TokenOrRequest, TokenProvider};
 pub use {
     eu::EndUserCredentials,
@@ -209,6 +210,46 @@ impl TokenProvider for TokenProviderWrapper {
             Self::EndUser(x) => x.parse_token_response(hash, response),
             Self::Metadata(x) => x.parse_token_response(hash, response),
             Self::ServiceAccount(x) => x.parse_token_response(hash, response),
+        }
+    }
+}
+
+impl IDTokenProvider for TokenProviderWrapper {
+    fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error> {
+        match self {
+            Self::EndUser(x) => x.get_id_token(audience),
+            Self::Metadata(x) => x.get_id_token(audience),
+            Self::ServiceAccount(x) => x.get_id_token(audience),
+        }
+    }
+
+    fn get_id_token_with_access_token<S>(
+        &self,
+        audience: &str,
+        response: crate::id_token::AccessTokenResponse<S>,
+    ) -> Result<crate::id_token::IDTokenRequest, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        match self {
+            Self::EndUser(x) => x.get_id_token_with_access_token(audience, response),
+            Self::Metadata(x) => x.get_id_token_with_access_token(audience, response),
+            Self::ServiceAccount(x) => x.get_id_token_with_access_token(audience, response),
+        }
+    }
+
+    fn parse_id_token_response<S>(
+        &self,
+        hash: u64,
+        response: http::Response<S>,
+    ) -> Result<IDToken, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        match self {
+            Self::EndUser(x) => x.parse_id_token_response(hash, response),
+            Self::Metadata(x) => x.parse_id_token_response(hash, response),
+            Self::ServiceAccount(x) => x.parse_id_token_response(hash, response),
         }
     }
 }

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -149,7 +149,7 @@ impl TokenProviderWrapper {
             }
         }
 
-        // Finaly, if we are on GCP, use the metadata server. If we're not on
+        // Finally, if we are on GCP, use the metadata server. If we're not on
         // GCP, this will just fail to read the file.
         if let Ok(full_name) = read_to_string("/sys/class/dmi/id/product_name") {
             // The product name can annoyingly include a newline...

--- a/src/gcp/service_account.rs
+++ b/src/gcp/service_account.rs
@@ -1,11 +1,18 @@
+use std::convert::TryInto;
+
 use super::{
     jwt::{self, Algorithm, Header, Key},
     TokenResponse,
 };
 use crate::{
     error::{self, Error},
+    id_token::{
+        AccessTokenRequest, AccessTokenResponse, IDTokenOrRequest, IDTokenProvider, IDTokenRequest,
+        IDTokenResponse,
+    },
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
     token_cache::CachedTokenProvider,
+    IDToken,
 };
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -19,6 +26,12 @@ pub struct ServiceAccountInfo {
     pub client_email: String,
     /// The URI we send the token requests to, eg <https://oauth2.googleapis.com/token>
     pub token_uri: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct IDTokenResponseBody {
+    /// The actual token
+    token: String,
 }
 
 impl ServiceAccountInfo {
@@ -88,16 +101,12 @@ impl ServiceAccountProviderInner {
     pub fn get_account_info(&self) -> &ServiceAccountInfo {
         &self.info
     }
-}
 
-impl TokenProvider for ServiceAccountProviderInner {
-    /// Like [`ServiceAccountProviderInner::get_token`], but allows the JWT "subject"
-    /// to be passed in.
-    fn get_token_with_subject<'a, S, I, T>(
+    fn prepare_access_token_request<'a, S, I, T>(
         &self,
         subject: Option<T>,
         scopes: I,
-    ) -> Result<TokenOrRequest, Error>
+    ) -> Result<AccessTokenRequest, Error>
     where
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
@@ -145,10 +154,28 @@ impl TokenProvider for ServiceAccountProviderInner {
             .header(http::header::CONTENT_LENGTH, body.len())
             .body(body)?;
 
+        Ok(request)
+    }
+}
+
+impl TokenProvider for ServiceAccountProviderInner {
+    /// Like [`ServiceAccountProviderInner::get_token`], but allows the JWT "subject"
+    /// to be passed in.
+    fn get_token_with_subject<'a, S, I, T>(
+        &self,
+        subject: Option<T>,
+        scopes: I,
+    ) -> Result<TokenOrRequest, Error>
+    where
+        S: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a S>,
+        T: Into<String>,
+    {
+        let request = self.prepare_access_token_request(subject, scopes)?;
         Ok(TokenOrRequest::Request {
-            reason: RequestReason::ScopesChanged,
+            reason: RequestReason::ParametersChanged,
             request,
-            scope_hash: 0,
+            hash: 0,
         })
     }
 
@@ -185,6 +212,86 @@ impl TokenProvider for ServiceAccountProviderInner {
 
         let token_res: TokenResponse = serde_json::from_slice(body.as_ref())?;
         let token: Token = token_res.into();
+
+        Ok(token)
+    }
+}
+
+impl IDTokenProvider for ServiceAccountProviderInner {
+    fn get_id_token(&self, _audience: &str) -> Result<IDTokenOrRequest, Error> {
+        let request = self
+            .prepare_access_token_request(None::<&str>, &["https://www.googleapis.com/auth/iam"])?;
+
+        Ok(IDTokenOrRequest::AccessTokenRequest {
+            request,
+            reason: RequestReason::ParametersChanged,
+            hash: 0,
+        })
+    }
+
+    fn get_id_token_with_access_token<S>(
+        &self,
+        audience: &str,
+        response: AccessTokenResponse<S>,
+    ) -> Result<IDTokenRequest, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let token = self.parse_token_response(0, response)?;
+
+        let sa_email = self.info.client_email.clone();
+        // See https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oidc
+        // for details on what it is we're doing
+        let json_body = serde_json::to_vec(&serde_json::json!({
+            "audience": audience,
+            "includeEmail": true,
+        }))?;
+
+        let token_header_value: http::HeaderValue = token.try_into()?;
+
+        let request = http::Request::builder()
+            .method("POST")
+            .uri(format!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateIdToken", sa_email))
+            .header(
+                http::header::CONTENT_TYPE,
+                "application/json; charset=utf-8",
+            )
+            .header(http::header::CONTENT_LENGTH, json_body.len())
+            .header(http::header::AUTHORIZATION, token_header_value)
+            .body(json_body)?;
+
+        Ok(request)
+    }
+
+    fn parse_id_token_response<S>(
+        &self,
+        _hash: u64,
+        response: IDTokenResponse<S>,
+    ) -> Result<IDToken, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let (parts, body) = response.into_parts();
+
+        if !parts.status.is_success() {
+            let body_bytes = body.as_ref();
+
+            if parts
+                .headers
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|ct| ct.to_str().ok())
+                == Some("application/json; charset=utf-8")
+            {
+                if let Ok(auth_error) = serde_json::from_slice::<error::AuthError>(body_bytes) {
+                    return Err(Error::Auth(auth_error));
+                }
+            }
+
+            return Err(Error::HttpStatus(parts.status));
+        }
+
+        let token_res: IDTokenResponseBody = serde_json::from_slice(body.as_ref())?;
+        let token = IDToken::new(token_res.token)?;
 
         Ok(token)
     }

--- a/src/gcp/service_account.rs
+++ b/src/gcp/service_account.rs
@@ -17,7 +17,7 @@ use crate::{
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
-/// Minimal parts needed from a GCP service acccount key for token acquisition
+/// Minimal parts needed from a GCP service account key for token acquisition
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct ServiceAccountInfo {
     /// The private key we use to sign

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -1,0 +1,122 @@
+use std::time::SystemTime;
+
+use crate::{token::RequestReason, Error, ExpiarableToken};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct IDToken {
+    pub token: String,
+    pub expiration: u64,
+}
+
+impl IDToken {
+    pub fn new(token: String) -> Result<IDToken, Error> {
+        // Extract the exp claim from the token, so we can know if the token is expired or not.
+        let claims = token
+            .split('.').nth(1)
+            .ok_or(Error::InvalidTokenFormat)?;
+
+        let decoded = base64::decode(claims)?;
+        let claims: TokenClaims = serde_json::from_slice(&decoded)?;
+
+        Ok(Self {
+            token,
+            expiration: claims.exp,
+        })
+    }
+}
+
+impl ExpiarableToken for IDToken {
+    /// Returns true if token is expired.
+    #[inline]
+    fn has_expired(&self) -> bool {
+        if self.token.is_empty() {
+            return true;
+        }
+
+        let expiry = SystemTime::UNIX_EPOCH
+            .checked_add(std::time::Duration::from_secs(self.expiration))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        expiry <= SystemTime::now()
+    }
+}
+
+pub enum IDTokenOrRequest {
+    AccessTokenRequest {
+        request: AccessTokenRequest,
+        reason: RequestReason,
+        hash: u64,
+    },
+    IDTokenRequest {
+        request: IDTokenRequest,
+        reason: RequestReason,
+        hash: u64,
+    },
+    IDToken(IDToken),
+}
+
+pub type IDTokenRequest = http::Request<Vec<u8>>;
+pub type AccessTokenRequest = http::Request<Vec<u8>>;
+
+pub type AccessTokenResponse<S> = http::Response<S>;
+pub type IDTokenResponse<S> = http::Response<S>;
+
+/// A `IDTokenProvider` has a single method to implement `get_token`.
+/// Implementations are free to perform caching or always return a `Request` in
+/// the `TokenOrRequest`.
+pub trait IDTokenProvider {
+    /// Attemps to retrieve an id token that can be used when communicating via IAP etc.
+    fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error>;
+
+    /// Some token sources require a access token to be used to generte a id token.
+    /// If `get_id_token` returns a `AccessTokenResponse`, this method should be called.
+    fn get_id_token_with_access_token<S>(
+        &self,
+        audience: &str,
+        response: AccessTokenResponse<S>,
+    ) -> Result<IDTokenRequest, Error>
+    where
+        S: AsRef<[u8]>;
+
+    /// Once a response has been received for an id token requst, call this method
+    /// to deserialize the token.
+    fn parse_id_token_response<S>(
+        &self,
+        hash: u64,
+        response: IDTokenResponse<S>,
+    ) -> Result<IDToken, Error>
+    where
+        S: AsRef<[u8]>;
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct TokenClaims {
+    exp: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IDToken;
+
+    #[test]
+    fn test_decode_jwt() {
+        /* raw token claims
+        {
+            "aud": "my-aud",
+            "azp": "123",
+            "email": "test@example.com",
+            "email_verified": true,
+            "exp": 1676641773,
+            "iat": 1676638173,
+            "iss": "https://accounts.google.com",
+            "sub": "123"
+        }
+        */
+
+        let raw_token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJteS1hdWQiLCJhenAiOiIxMjMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxNjc2NjQxNzczLCJpYXQiOjE2NzY2MzgxNzMsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsInN1YiI6IjEyMyJ9.plHXcnUDNzWo4PVOAPiwoQJ7QIvecKhmCbfxaIsxpbbGyXFdOdLM2T0Qtbbm2FxwsryabNxv0DY_iQhXlCa1dv2ksusjZAj0MXEE3aEEi65rxxAhE_ew3eU03GheZOjG4oR2gMja8B_8_CoBOK7k7wt_Ggbph0iWIEG6_0YygjJdWHZhxeckn6ym6hQB2MkxYkv0MK2A_68e05edsar1VIvcpgOMcrMwcCNDClclx7A1Ci3pMk1vSdJ-1pHw_GAwb7XCEdB2E9Ccm9N7J0WddvC4W09CxXDYiOcVFxj2Lnr53wquHE0hJcNrp-6tYXKALfXUnx1Nn2XWA0a3ehpHMA";
+        let id_token = IDToken::new(raw_token.to_owned()).unwrap();
+
+        assert_eq!(id_token.token, raw_token);
+        assert_eq!(id_token.expiration, 1676641773);
+    }
+}

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -59,9 +59,7 @@ pub type AccessTokenRequest = http::Request<Vec<u8>>;
 pub type AccessTokenResponse<S> = http::Response<S>;
 pub type IDTokenResponse<S> = http::Response<S>;
 
-/// A `IDTokenProvider` has a single method to implement `get_token`.
-/// Implementations are free to perform caching or always return a `Request` in
-/// the `TokenOrRequest`.
+/// A `IDTokenProvider` supplies all methods needed for all different flows to get a id token.
 pub trait IDTokenProvider {
     /// Attempts to retrieve an id token that can be used when communicating via IAP etc.
     fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error>;
@@ -76,7 +74,7 @@ pub trait IDTokenProvider {
     where
         S: AsRef<[u8]>;
 
-    /// Once a response has been received for an id token request, call this method
+    /// Once a `IDTokenResponse` has been received for an id token request, call this method
     /// to deserialize the token.
     fn parse_id_token_response<S>(
         &self,

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -11,9 +11,7 @@ pub struct IDToken {
 impl IDToken {
     pub fn new(token: String) -> Result<IDToken, Error> {
         // Extract the exp claim from the token, so we can know if the token is expired or not.
-        let claims = token
-            .split('.').nth(1)
-            .ok_or(Error::InvalidTokenFormat)?;
+        let claims = token.split('.').nth(1).ok_or(Error::InvalidTokenFormat)?;
 
         let decoded = base64::decode(claims)?;
         let claims: TokenClaims = serde_json::from_slice(&decoded)?;
@@ -65,7 +63,7 @@ pub type IDTokenResponse<S> = http::Response<S>;
 /// Implementations are free to perform caching or always return a `Request` in
 /// the `TokenOrRequest`.
 pub trait IDTokenProvider {
-    /// Attemps to retrieve an id token that can be used when communicating via IAP etc.
+    /// Attempts to retrieve an id token that can be used when communicating via IAP etc.
     fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error>;
 
     /// Some token sources require a access token to be used to generte a id token.
@@ -78,7 +76,7 @@ pub trait IDTokenProvider {
     where
         S: AsRef<[u8]>;
 
-    /// Once a response has been received for an id token requst, call this method
+    /// Once a response has been received for an id token request, call this method
     /// to deserialize the token.
     fn parse_id_token_response<S>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,12 @@ pub mod gcp;
 mod jwt;
 
 mod error;
+mod id_token;
 mod token;
 mod token_cache;
 
-pub use crate::{error::Error, token::Token};
+pub use crate::{error::Error, id_token::IDToken, token::Token};
+
+pub trait ExpiarableToken {
+    fn has_expired(&self) -> bool;
+}

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -70,7 +70,7 @@ impl<T> TokenCache<T> {
 }
 
 /// Wraps a `TokenProvider` in a cache, only invokes the inner `TokenProvider` if
-/// the token in cache is expired, or if it doesn't exsist.
+/// the token in cache is expired, or if it doesn't exist.
 pub struct CachedTokenProvider<P> {
     access_tokens: TokenCache<Token>,
     id_tokens: TokenCache<IDToken>,


### PR DESCRIPTION
Adds an `IDTokenProvider` for implementing flows for fetching ID tokens.

In the case of service accounts as a token source, we first need to fetch a access token, and using that we can fetch the id token. With both the metadata server flow and user credentials flow we can fetch the id token directly. Therefore the interface is a bit messy as it needs to support all of them.
(See `examples/svc_account_id_token.rs` for example of the service account flow)

If we go with this, I wonder if it would make sense to also rename `Token` to `AccessToken` as well, to keep the code a bit more understandable?

Fixes #46