### PR TITLE
Cleanup Id Tokens

### DIFF
--- a/examples/default_creds_id_token.rs
+++ b/examples/default_creds_id_token.rs
@@ -20,7 +20,7 @@ async fn main() {
     // will also happen if we want to get a token for a different
     // audience, or if the token has expired.
     match provider.get_id_token("my-audience").unwrap() {
-        IDTokenOrRequest::IDTokenRequest {
+        IdTokenOrRequest::IdTokenRequest {
             // This is an http::Request that we can use to build
             // a client request for whichever HTTP client implementation
             // you wish to use

--- a/examples/svc_account_id_token.rs
+++ b/examples/svc_account_id_token.rs
@@ -30,7 +30,7 @@ async fn main() {
     // will also happen if we want to get a token for a different
     // audience, or if the token has expired.
     let token = match sa_provider.get_id_token(audience).unwrap() {
-        IDTokenOrRequest::AccessTokenRequest {
+        IdTokenOrRequest::AccessTokenRequest {
             request,
             audience_hash,
             ..
@@ -57,7 +57,7 @@ async fn main() {
     // Retrieving a token for the same scopes for which a token has been acquired
     // will use the cached token until it expires
     match sa_provider.get_id_token(audience).unwrap() {
-        IDTokenOrRequest::IDToken(tk) => {
+        IdTokenOrRequest::IdToken(tk) => {
             assert_eq!(tk, token);
             println!(
                 "cool, you were able to retrieve a token with aud {}!",

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -53,7 +53,7 @@ impl TokenProviderWrapper {
     /// contains invalid JSON, an error is returned with the details
     pub fn get_default_provider() -> Result<Option<Self>, Error> {
         TokenProviderWrapperInner::get_default_provider()
-            .map(|provider| provider.map(|provider| CachedTokenProvider::wrap(provider)))
+            .map(|provider| provider.map(CachedTokenProvider::wrap))
     }
 
     /// Gets the kind of token provider

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -60,6 +60,16 @@ impl TokenProviderWrapper {
     pub fn kind(&self) -> &'static str {
         self.inner().kind()
     }
+
+    pub fn is_service_account_provider(&self) -> bool {
+        self.inner().is_service_account_provider()
+    }
+    pub fn is_metadata_server_provider(&self) -> bool {
+        self.inner().is_metadata_server_provider()
+    }
+    pub fn is_end_user_credentials_provider(&self) -> bool {
+        self.inner().is_end_user_credentials_provider()
+    }
 }
 
 /// Wrapper around the different providers that are supported. Implements both `TokenProvider` and `IDTokenProvider`.
@@ -195,6 +205,16 @@ impl TokenProviderWrapperInner {
             Self::Metadata(_) => "Metadata Server",
             Self::ServiceAccount(_) => "Service Account",
         }
+    }
+
+    pub fn is_service_account_provider(&self) -> bool {
+        matches!(self, TokenProviderWrapperInner::ServiceAccount(_))
+    }
+    pub fn is_metadata_server_provider(&self) -> bool {
+        matches!(self, TokenProviderWrapperInner::Metadata(_))
+    }
+    pub fn is_end_user_credentials_provider(&self) -> bool {
+        matches!(self, TokenProviderWrapperInner::EndUser(_))
     }
 }
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -12,7 +12,7 @@ use end_user as eu;
 use metadata_server as ms;
 use service_account as sa;
 
-pub use crate::id_token::{IDToken, IDTokenOrRequest, IDTokenProvider};
+pub use crate::id_token::{IdToken, IdTokenOrRequest, IdTokenProvider};
 pub use crate::token::{Token, TokenOrRequest, TokenProvider};
 pub use {
     end_user::{EndUserCredentials, EndUserCredentialsInfo},
@@ -72,7 +72,7 @@ impl TokenProviderWrapper {
     }
 }
 
-/// Wrapper around the different providers that are supported. Implements both `TokenProvider` and `IDTokenProvider`.
+/// Wrapper around the different providers that are supported. Implements both `TokenProvider` and `IdTokenProvider`.
 /// Should not be used directly as it is not cached. Use `TokenProviderWrapper` instead.
 pub enum TokenProviderWrapperInner {
     EndUser(eu::EndUserCredentialsInner),
@@ -258,8 +258,8 @@ impl TokenProvider for TokenProviderWrapperInner {
     }
 }
 
-impl IDTokenProvider for TokenProviderWrapperInner {
-    fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error> {
+impl IdTokenProvider for TokenProviderWrapperInner {
+    fn get_id_token(&self, audience: &str) -> Result<IdTokenOrRequest, Error> {
         match self {
             Self::EndUser(token_provider) => token_provider.get_id_token(audience),
             Self::Metadata(token_provider) => token_provider.get_id_token(audience),
@@ -271,7 +271,7 @@ impl IDTokenProvider for TokenProviderWrapperInner {
         &self,
         audience: &str,
         response: crate::id_token::AccessTokenResponse<S>,
-    ) -> Result<crate::id_token::IDTokenRequest, Error>
+    ) -> Result<crate::id_token::IdTokenRequest, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -292,7 +292,7 @@ impl IDTokenProvider for TokenProviderWrapperInner {
         &self,
         hash: u64,
         response: http::Response<S>,
-    ) -> Result<IDToken, Error>
+    ) -> Result<IdToken, Error>
     where
         S: AsRef<[u8]>,
     {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,6 +1,7 @@
 //! Provides functionality for
 //! [Google oauth](https://developers.google.com/identity/protocols/oauth2)
 
+use crate::token_cache::CachedTokenProvider;
 use crate::{error::Error, jwt};
 
 pub mod end_user;
@@ -31,13 +32,7 @@ struct TokenResponse {
     expires_in: i64,
 }
 
-/// Wrapper around the different providers that are supported. Implements both `TokenProvider` and `IDTokenProvider`.
-pub enum TokenProviderWrapper {
-    EndUser(eu::EndUserCredentials),
-    Metadata(ms::MetadataServerProvider),
-    ServiceAccount(sa::ServiceAccountProvider),
-}
-
+pub type TokenProviderWrapper = CachedTokenProvider<TokenProviderWrapperInner>;
 impl TokenProviderWrapper {
     /// Get a `TokenProvider` following the "Google Default Credentials"
     /// flow, in order:
@@ -56,6 +51,29 @@ impl TokenProviderWrapper {
     /// If it appears that a method is being used, but is actually invalid,
     /// eg `GOOGLE_APPLICATION_CREDENTIALS` is set but the file doesn't exist or
     /// contains invalid JSON, an error is returned with the details
+    pub fn get_default_provider() -> Result<Option<Self>, Error> {
+        TokenProviderWrapperInner::get_default_provider()
+            .map(|provider| provider.map(|provider| CachedTokenProvider::wrap(provider)))
+    }
+
+    /// Gets the kind of token provider
+    pub fn kind(&self) -> &'static str {
+        self.inner().kind()
+    }
+}
+
+/// Wrapper around the different providers that are supported. Implements both `TokenProvider` and `IDTokenProvider`.
+/// Should not be used directly as it is not cached. Use `TokenProviderWrapper` instead.
+pub enum TokenProviderWrapperInner {
+    EndUser(eu::EndUserCredentialsInner),
+    Metadata(ms::MetadataServerProviderInner),
+    ServiceAccount(sa::ServiceAccountProviderInner),
+}
+
+impl TokenProviderWrapperInner {
+    /// Get a `TokenProvider` following the "Google Default Credentials" flow.
+    /// Returns a uncached token provider, use `TokenProviderWrapper::get_default_provider`
+    /// instead.
     pub fn get_default_provider() -> Result<Option<Self>, Error> {
         use std::{fs::read_to_string, path::PathBuf};
 
@@ -82,8 +100,8 @@ impl TokenProviderWrapper {
                 }
             };
 
-            return Ok(Some(TokenProviderWrapper::ServiceAccount(
-                sa::ServiceAccountProvider::new(sa_info).map_err(|e| {
+            return Ok(Some(TokenProviderWrapperInner::ServiceAccount(
+                sa::ServiceAccountProviderInner::new(sa_info).map_err(|e| {
                     Error::InvalidCredentials {
                         file: cred_path.into(),
                         error: Box::new(e),
@@ -134,8 +152,8 @@ impl TokenProviderWrapper {
                         error: Box::new(e),
                     })?;
 
-                    return Ok(Some(TokenProviderWrapper::EndUser(
-                        eu::EndUserCredentials::new(end_user_credentials),
+                    return Ok(Some(TokenProviderWrapperInner::EndUser(
+                        eu::EndUserCredentialsInner::new(end_user_credentials),
                     )));
                 }
                 // Skip not found errors, and fall back to the metadata server check
@@ -158,8 +176,8 @@ impl TokenProviderWrapper {
                 // This matches the Golang client. If new products
                 // add additional values, this will need to be updated.
                 "Google" | "Google Compute Engine" => {
-                    return Ok(Some(TokenProviderWrapper::Metadata(
-                        ms::MetadataServerProvider::new(None),
+                    return Ok(Some(TokenProviderWrapperInner::Metadata(
+                        ms::MetadataServerProviderInner::new(None),
                     )));
                 }
                 _ => {}
@@ -180,7 +198,7 @@ impl TokenProviderWrapper {
     }
 }
 
-impl TokenProvider for TokenProviderWrapper {
+impl TokenProvider for TokenProviderWrapperInner {
     fn get_token_with_subject<'a, S, I, T>(
         &self,
         subject: Option<T>,
@@ -192,9 +210,13 @@ impl TokenProvider for TokenProviderWrapper {
         T: Into<String>,
     {
         match self {
-            Self::EndUser(x) => x.get_token_with_subject(subject, scopes),
-            Self::Metadata(x) => x.get_token_with_subject(subject, scopes),
-            Self::ServiceAccount(x) => x.get_token_with_subject(subject, scopes),
+            Self::EndUser(token_provider) => token_provider.get_token_with_subject(subject, scopes),
+            Self::Metadata(token_provider) => {
+                token_provider.get_token_with_subject(subject, scopes)
+            }
+            Self::ServiceAccount(token_provider) => {
+                token_provider.get_token_with_subject(subject, scopes)
+            }
         }
     }
 
@@ -207,19 +229,21 @@ impl TokenProvider for TokenProviderWrapper {
         S: AsRef<[u8]>,
     {
         match self {
-            Self::EndUser(x) => x.parse_token_response(hash, response),
-            Self::Metadata(x) => x.parse_token_response(hash, response),
-            Self::ServiceAccount(x) => x.parse_token_response(hash, response),
+            Self::EndUser(token_provider) => token_provider.parse_token_response(hash, response),
+            Self::Metadata(token_provider) => token_provider.parse_token_response(hash, response),
+            Self::ServiceAccount(token_provider) => {
+                token_provider.parse_token_response(hash, response)
+            }
         }
     }
 }
 
-impl IDTokenProvider for TokenProviderWrapper {
+impl IDTokenProvider for TokenProviderWrapperInner {
     fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error> {
         match self {
-            Self::EndUser(x) => x.get_id_token(audience),
-            Self::Metadata(x) => x.get_id_token(audience),
-            Self::ServiceAccount(x) => x.get_id_token(audience),
+            Self::EndUser(token_provider) => token_provider.get_id_token(audience),
+            Self::Metadata(token_provider) => token_provider.get_id_token(audience),
+            Self::ServiceAccount(token_provider) => token_provider.get_id_token(audience),
         }
     }
 
@@ -232,9 +256,15 @@ impl IDTokenProvider for TokenProviderWrapper {
         S: AsRef<[u8]>,
     {
         match self {
-            Self::EndUser(x) => x.get_id_token_with_access_token(audience, response),
-            Self::Metadata(x) => x.get_id_token_with_access_token(audience, response),
-            Self::ServiceAccount(x) => x.get_id_token_with_access_token(audience, response),
+            Self::EndUser(token_provider) => {
+                token_provider.get_id_token_with_access_token(audience, response)
+            }
+            Self::Metadata(token_provider) => {
+                token_provider.get_id_token_with_access_token(audience, response)
+            }
+            Self::ServiceAccount(token_provider) => {
+                token_provider.get_id_token_with_access_token(audience, response)
+            }
         }
     }
 
@@ -247,9 +277,13 @@ impl IDTokenProvider for TokenProviderWrapper {
         S: AsRef<[u8]>,
     {
         match self {
-            Self::EndUser(x) => x.parse_id_token_response(hash, response),
-            Self::Metadata(x) => x.parse_id_token_response(hash, response),
-            Self::ServiceAccount(x) => x.parse_id_token_response(hash, response),
+            Self::EndUser(token_provider) => token_provider.parse_id_token_response(hash, response),
+            Self::Metadata(token_provider) => {
+                token_provider.parse_id_token_response(hash, response)
+            }
+            Self::ServiceAccount(token_provider) => {
+                token_provider.parse_id_token_response(hash, response)
+            }
         }
     }
 }

--- a/src/gcp/end_user.rs
+++ b/src/gcp/end_user.rs
@@ -2,11 +2,11 @@ use super::TokenResponse;
 use crate::{
     error::{self, Error},
     id_token::{
-        AccessTokenResponse, IDTokenOrRequest, IDTokenProvider, IDTokenRequest, IDTokenResponse,
+        AccessTokenResponse, IdTokenOrRequest, IdTokenProvider, IdTokenRequest, IdTokenResponse,
     },
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
     token_cache::CachedTokenProvider,
-    IDToken,
+    IdToken,
 };
 
 /// Provides tokens using
@@ -63,7 +63,7 @@ impl EndUserCredentialsInner {
 }
 
 #[derive(serde::Deserialize, Debug)]
-struct IDTokenResponseBody {
+struct IdTokenResponseBody {
     /// The actual token
     id_token: String,
 }
@@ -165,11 +165,11 @@ impl TokenProvider for EndUserCredentialsInner {
     }
 }
 
-impl IDTokenProvider for EndUserCredentialsInner {
-    fn get_id_token(&self, _audience: &str) -> Result<IDTokenOrRequest, Error> {
+impl IdTokenProvider for EndUserCredentialsInner {
+    fn get_id_token(&self, _audience: &str) -> Result<IdTokenOrRequest, Error> {
         let request = self.prepare_token_request()?;
 
-        Ok(IDTokenOrRequest::IDTokenRequest {
+        Ok(IdTokenOrRequest::IdTokenRequest {
             request,
             reason: RequestReason::ParametersChanged,
             audience_hash: 0,
@@ -180,7 +180,7 @@ impl IDTokenProvider for EndUserCredentialsInner {
         &self,
         _audience: &str,
         _response: AccessTokenResponse<S>,
-    ) -> Result<IDTokenRequest, Error>
+    ) -> Result<IdTokenRequest, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -197,8 +197,8 @@ impl IDTokenProvider for EndUserCredentialsInner {
     fn parse_id_token_response<S>(
         &self,
         _hash: u64,
-        response: IDTokenResponse<S>,
-    ) -> Result<IDToken, Error>
+        response: IdTokenResponse<S>,
+    ) -> Result<IdToken, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -221,8 +221,8 @@ impl IDTokenProvider for EndUserCredentialsInner {
             return Err(Error::HttpStatus(parts.status));
         }
 
-        let token_res: IDTokenResponseBody = serde_json::from_slice(body.as_ref())?;
-        let token = IDToken::new(token_res.id_token)?;
+        let token_res: IdTokenResponseBody = serde_json::from_slice(body.as_ref())?;
+        let token = IdToken::new(token_res.id_token)?;
 
         Ok(token)
     }

--- a/src/gcp/metadata_server.rs
+++ b/src/gcp/metadata_server.rs
@@ -228,7 +228,7 @@ mod test {
     fn wrapper_dispatch() {
         // Wrap the metadata server provider.
         let provider =
-            crate::gcp::TokenProviderWrapper::Metadata(MetadataServerProvider::new(None));
+            crate::gcp::TokenProviderWrapperInner::Metadata(MetadataServerProviderInner::new(None));
 
         // And then have the same test as metadata_with_scopes
         let scopes = ["scope1", "scope2"];

--- a/src/gcp/metadata_server.rs
+++ b/src/gcp/metadata_server.rs
@@ -1,10 +1,10 @@
 use super::TokenResponse;
 use crate::{
     error::{self, Error},
-    id_token::{IDTokenOrRequest, IDTokenProvider},
+    id_token::{IdTokenOrRequest, IdTokenProvider},
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
     token_cache::CachedTokenProvider,
-    IDToken,
+    IdToken,
 };
 
 const METADATA_URL: &str =
@@ -111,8 +111,8 @@ impl TokenProvider for MetadataServerProviderInner {
     }
 }
 
-impl IDTokenProvider for MetadataServerProviderInner {
-    fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, error::Error> {
+impl IdTokenProvider for MetadataServerProviderInner {
+    fn get_id_token(&self, audience: &str) -> Result<IdTokenOrRequest, error::Error> {
         let url = format!(
             "{}/{}/identity?audience={}",
             METADATA_URL, self.account_name, audience,
@@ -124,7 +124,7 @@ impl IDTokenProvider for MetadataServerProviderInner {
             .header("Metadata-Flavor", "Google")
             .body(Vec::new())?;
 
-        Ok(IDTokenOrRequest::IDTokenRequest {
+        Ok(IdTokenOrRequest::IdTokenRequest {
             request,
             reason: RequestReason::ParametersChanged,
             audience_hash: 0,
@@ -135,7 +135,7 @@ impl IDTokenProvider for MetadataServerProviderInner {
         &self,
         _hash: u64,
         response: http::Response<S>,
-    ) -> Result<IDToken, Error>
+    ) -> Result<IdToken, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -145,7 +145,7 @@ impl IDTokenProvider for MetadataServerProviderInner {
             return Err(Error::HttpStatus(parts.status));
         }
 
-        let token = IDToken::new(String::from_utf8_lossy(body.as_ref()).into_owned())?;
+        let token = IdToken::new(String::from_utf8_lossy(body.as_ref()).into_owned())?;
 
         Ok(token)
     }
@@ -154,7 +154,7 @@ impl IDTokenProvider for MetadataServerProviderInner {
         &self,
         _audience: &str,
         _access_token_resp: crate::id_token::AccessTokenResponse<S>,
-    ) -> Result<crate::id_token::IDTokenRequest, Error>
+    ) -> Result<crate::id_token::IdTokenRequest, Error>
     where
         S: AsRef<[u8]>,
     {

--- a/src/gcp/service_account.rs
+++ b/src/gcp/service_account.rs
@@ -7,12 +7,12 @@ use super::{
 use crate::{
     error::{self, Error},
     id_token::{
-        AccessTokenRequest, AccessTokenResponse, IDTokenOrRequest, IDTokenProvider, IDTokenRequest,
-        IDTokenResponse,
+        AccessTokenRequest, AccessTokenResponse, IdTokenOrRequest, IdTokenProvider, IdTokenRequest,
+        IdTokenResponse,
     },
     token::{RequestReason, Token, TokenOrRequest, TokenProvider},
     token_cache::CachedTokenProvider,
-    IDToken,
+    IdToken,
 };
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -29,7 +29,7 @@ pub struct ServiceAccountInfo {
 }
 
 #[derive(serde::Deserialize, Debug)]
-struct IDTokenResponseBody {
+struct IdTokenResponseBody {
     /// The actual token
     token: String,
 }
@@ -217,12 +217,12 @@ impl TokenProvider for ServiceAccountProviderInner {
     }
 }
 
-impl IDTokenProvider for ServiceAccountProviderInner {
-    fn get_id_token(&self, _audience: &str) -> Result<IDTokenOrRequest, Error> {
+impl IdTokenProvider for ServiceAccountProviderInner {
+    fn get_id_token(&self, _audience: &str) -> Result<IdTokenOrRequest, Error> {
         let request = self
             .prepare_access_token_request(None::<&str>, &["https://www.googleapis.com/auth/iam"])?;
 
-        Ok(IDTokenOrRequest::AccessTokenRequest {
+        Ok(IdTokenOrRequest::AccessTokenRequest {
             request,
             reason: RequestReason::ParametersChanged,
             audience_hash: 0,
@@ -233,7 +233,7 @@ impl IDTokenProvider for ServiceAccountProviderInner {
         &self,
         audience: &str,
         response: AccessTokenResponse<S>,
-    ) -> Result<IDTokenRequest, Error>
+    ) -> Result<IdTokenRequest, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -266,8 +266,8 @@ impl IDTokenProvider for ServiceAccountProviderInner {
     fn parse_id_token_response<S>(
         &self,
         _hash: u64,
-        response: IDTokenResponse<S>,
-    ) -> Result<IDToken, Error>
+        response: IdTokenResponse<S>,
+    ) -> Result<IdToken, Error>
     where
         S: AsRef<[u8]>,
     {
@@ -290,8 +290,8 @@ impl IDTokenProvider for ServiceAccountProviderInner {
             return Err(Error::HttpStatus(parts.status));
         }
 
-        let token_res: IDTokenResponseBody = serde_json::from_slice(body.as_ref())?;
-        let token = IDToken::new(token_res.token)?;
+        let token_res: IdTokenResponseBody = serde_json::from_slice(body.as_ref())?;
+        let token = IdToken::new(token_res.token)?;
 
         Ok(token)
     }

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -4,13 +4,13 @@ use crate::{token::RequestReason, token_cache::CacheableToken, Error};
 
 /// Represents a id token as returned by `OAuth2` servers.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct IDToken {
+pub struct IdToken {
     pub token: String,
     pub expiration: SystemTime,
 }
 
-impl IDToken {
-    pub fn new(token: String) -> Result<IDToken, Error> {
+impl IdToken {
+    pub fn new(token: String) -> Result<IdToken, Error> {
         // Extract the exp claim from the token, so we can know if the token is expired or not.
         let claims = token.split('.').nth(1).ok_or(Error::InvalidTokenFormat)?;
 
@@ -26,7 +26,7 @@ impl IDToken {
     }
 }
 
-impl CacheableToken for IDToken {
+impl CacheableToken for IdToken {
     /// Returns true if token is expired.
     #[inline]
     fn has_expired(&self) -> bool {
@@ -41,30 +41,30 @@ impl CacheableToken for IDToken {
 /// Either a valid token, or an HTTP request. With some token sources, two different
 /// HTTP requests needs to be performed, one to get an access token and one to get
 /// the actual id token.
-pub enum IDTokenOrRequest {
+pub enum IdTokenOrRequest {
     AccessTokenRequest {
         request: AccessTokenRequest,
         reason: RequestReason,
         audience_hash: u64,
     },
-    IDTokenRequest {
-        request: IDTokenRequest,
+    IdTokenRequest {
+        request: IdTokenRequest,
         reason: RequestReason,
         audience_hash: u64,
     },
-    IDToken(IDToken),
+    IdToken(IdToken),
 }
 
-pub type IDTokenRequest = http::Request<Vec<u8>>;
+pub type IdTokenRequest = http::Request<Vec<u8>>;
 pub type AccessTokenRequest = http::Request<Vec<u8>>;
 
 pub type AccessTokenResponse<S> = http::Response<S>;
-pub type IDTokenResponse<S> = http::Response<S>;
+pub type IdTokenResponse<S> = http::Response<S>;
 
-/// A `IDTokenProvider` supplies all methods needed for all different flows to get a id token.
-pub trait IDTokenProvider {
+/// A `IdTokenProvider` supplies all methods needed for all different flows to get a id token.
+pub trait IdTokenProvider {
     /// Attempts to retrieve an id token that can be used when communicating via IAP etc.
-    fn get_id_token(&self, audience: &str) -> Result<IDTokenOrRequest, Error>;
+    fn get_id_token(&self, audience: &str) -> Result<IdTokenOrRequest, Error>;
 
     /// Some token sources require a access token to be used to generte a id token.
     /// If `get_id_token` returns a `AccessTokenResponse`, this method should be called.
@@ -72,17 +72,17 @@ pub trait IDTokenProvider {
         &self,
         audience: &str,
         response: AccessTokenResponse<S>,
-    ) -> Result<IDTokenRequest, Error>
+    ) -> Result<IdTokenRequest, Error>
     where
         S: AsRef<[u8]>;
 
-    /// Once a `IDTokenResponse` has been received for an id token request, call this method
+    /// Once a `IdTokenResponse` has been received for an id token request, call this method
     /// to deserialize the token.
     fn parse_id_token_response<S>(
         &self,
         hash: u64,
-        response: IDTokenResponse<S>,
-    ) -> Result<IDToken, Error>
+        response: IdTokenResponse<S>,
+    ) -> Result<IdToken, Error>
     where
         S: AsRef<[u8]>;
 }
@@ -96,7 +96,7 @@ struct TokenClaims {
 mod tests {
     use std::time::SystemTime;
 
-    use super::IDToken;
+    use super::IdToken;
 
     #[test]
     fn test_decode_jwt() {
@@ -114,7 +114,7 @@ mod tests {
         */
 
         let raw_token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYzEyMyIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJteS1hdWQiLCJhenAiOiIxMjMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxNjc2NjQxNzczLCJpYXQiOjE2NzY2MzgxNzMsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsInN1YiI6IjEyMyJ9.plHXcnUDNzWo4PVOAPiwoQJ7QIvecKhmCbfxaIsxpbbGyXFdOdLM2T0Qtbbm2FxwsryabNxv0DY_iQhXlCa1dv2ksusjZAj0MXEE3aEEi65rxxAhE_ew3eU03GheZOjG4oR2gMja8B_8_CoBOK7k7wt_Ggbph0iWIEG6_0YygjJdWHZhxeckn6ym6hQB2MkxYkv0MK2A_68e05edsar1VIvcpgOMcrMwcCNDClclx7A1Ci3pMk1vSdJ-1pHw_GAwb7XCEdB2E9Ccm9N7J0WddvC4W09CxXDYiOcVFxj2Lnr53wquHE0hJcNrp-6tYXKALfXUnx1Nn2XWA0a3ehpHMA";
-        let id_token = IDToken::new(raw_token.to_owned()).unwrap();
+        let id_token = IdToken::new(raw_token.to_owned()).unwrap();
 
         assert_eq!(id_token.token, raw_token);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,4 +89,4 @@ mod id_token;
 mod token;
 pub mod token_cache;
 
-pub use crate::{error::Error, id_token::IDToken, token::Token};
+pub use crate::{error::Error, id_token::IdToken, token::Token};

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -98,7 +98,7 @@ impl<P> CachedTokenProvider<P> {
         }
     }
 
-    /// Gets a reference to the wrapped token provider
+    /// Gets a reference to the wrapped (uncached) token provider
     pub fn inner(&self) -> &P {
         &self.inner
     }


### PR DESCRIPTION
Some cleanup before release.
- Follow Rust naming convetions, and rename IDToken to IdToken etc.
- Expose a SystemTime instead of seconds since epoch on id token
- add is_*_provider to TokenProviderWrapper for asserting the inner wrapper
- Move cache layer for TokenProviderWrapper to the outside, so that the inner is the "raw" provider