### PR TITLE
Upgrade `http` crate to `1.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wasm-web = ["ring/wasm32_unknown_unknown_js"]
 
 [dependencies]
 data-encoding = "2.4"
-http = "0.2"
+http = "1"
 ring = { version = "0.17", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
The `http` crate has finally received its `1.0.0` release, but this does require some effort to propagate through the crates.  As is the case here with the examples using `reqwest` which is still on `http 0.2`.
